### PR TITLE
Retry failed tests for stability

### DIFF
--- a/certificate_test.go
+++ b/certificate_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"errors"
+	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,35 +24,52 @@ func newOpt(h string) Opt {
 	return opt
 }
 
+func retryWithVerfy(opt Opt, retry int) (string, error) {
+	var err error
+	var msg string
+	for i := 0; i < retry; i++ {
+		msg, err = opt.Verify()
+		if err == nil {
+			return msg, nil
+		}
+		// connection reset by peer, retry
+		if errors.Is(err, net.ErrClosed) || errors.Is(err, net.ErrWriteToConnected) || strings.Contains(err.Error(), "connection reset by peer") {
+			continue
+		}
+		return msg, err
+	}
+	return msg, err
+}
+
 func TestVerifyOK(t *testing.T) {
 	opt := newOpt("badssl.com")
-	_, err := opt.Verify()
+	_, err := retryWithVerfy(opt, 3)
 	assert.NoError(t, err)
 }
 
 func TestWeakKeyExchange(t *testing.T) {
 	opt := newOpt("static-rsa.badssl.com")
-	_, err := opt.Verify()
+	_, err := retryWithVerfy(opt, 3)
 	assert.NoError(t, err)
 }
 
 func TestVerifyExpired(t *testing.T) {
 	{
 		opt := newOpt("expired.badssl.com")
-		_, err := opt.Verify()
+		_, err := retryWithVerfy(opt, 3)
 		assert.Error(t, err)
 	}
 }
 func TestVerifyWrongHost(t *testing.T) {
 	{
 		opt := newOpt("wrong.host.badssl.com")
-		_, err := opt.Verify()
+		_, err := retryWithVerfy(opt, 3)
 		assert.NoError(t, err)
 	}
 	{
 		opt := newOpt("wrong.host.badssl.com")
 		opt.VerifySNI = true
-		_, err := opt.Verify()
+		_, err := retryWithVerfy(opt, 3)
 		assert.Error(t, err)
 	}
 }
@@ -57,13 +77,13 @@ func TestVerifyWrongHost(t *testing.T) {
 func TestVerifySelfSigned(t *testing.T) {
 	{
 		opt := newOpt("self-signed.badssl.com")
-		_, err := opt.Verify()
+		_, err := retryWithVerfy(opt, 3)
 		assert.NoError(t, err)
 	}
 	{
 		opt := newOpt("self-signed.badssl.com")
 		opt.VerifyChains = true
-		_, err := opt.Verify()
+		_, err := retryWithVerfy(opt, 3)
 		assert.Error(t, err)
 	}
 }
@@ -71,13 +91,13 @@ func TestVerifySelfSigned(t *testing.T) {
 func TestVerifyUntrustRoot(t *testing.T) {
 	{
 		opt := newOpt("untrusted-root.badssl.com")
-		_, err := opt.Verify()
+		_, err := retryWithVerfy(opt, 3)
 		assert.NoError(t, err)
 	}
 	{
 		opt := newOpt("untrusted-root.badssl.com")
 		opt.VerifyChains = true
-		_, err := opt.Verify()
+		_, err := retryWithVerfy(opt, 3)
 		assert.Error(t, err)
 	}
 }


### PR DESCRIPTION
This pull request improves the reliability of certificate verification tests by introducing a retry mechanism to handle transient network errors such as "connection reset by peer." The main change is the addition of a helper function that retries the verification up to three times before failing, and updating all relevant tests to use this function.

**Test reliability improvements:**

* Added the `retryWithVerfy` helper function to `certificate_test.go`, which retries the `Opt.Verify()` call up to three times if certain network errors occur (e.g., `net.ErrClosed`, `net.ErrWriteToConnected`, or "connection reset by peer"). [[1]](diffhunk://#diff-4185515bb45885cbb5721004137f7b070175b9c8944448863631fe04a4686d51R4-R6) [[2]](diffhunk://#diff-4185515bb45885cbb5721004137f7b070175b9c8944448863631fe04a4686d51R27-R100)
* Updated all test cases in `certificate_test.go` to use `retryWithVerfy` instead of calling `Opt.Verify()` directly, improving test robustness against transient network failures.