### PR TITLE
fix: resolve lint issues and improve error handling in certificate verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,19 @@
 VERSION=0.0.8
-LDFLAGS=-ldflags "-w -s -X main.version=${VERSION} "
+GITCOMMIT?=$(shell git describe --dirty --always 2>/dev/null)
+LDFLAGS=-ldflags "-w -s -X main.version=${VERSION} -X main.commit=${GITCOMMIT}"
 
 all: check_ssl_certificate2
 
 .PHONY: check_ssl_certificate2
 
-check_ssl_certificate2: main.go certificate.go
-	go build $(LDFLAGS) -o check_ssl_certificate2 certificate.go main.go
+check_ssl_certificate2: *.go
+	go build $(LDFLAGS) -o check_ssl_certificate2
 
-linux: main.go certificate.go
-	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o check_ssl_certificate2 certificate.go main.go
+linux: *.go
+	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o check_ssl_certificate2
 
 check:
-	go test ./...
+	go test -v ./...
 
-fmt:
-	go fmt ./...
+lint:
+	golangci-lint run --timeout 5m ./...

--- a/certificate.go
+++ b/certificate.go
@@ -57,14 +57,18 @@ func (opt *Opt) Fetch() ([]*x509.Certificate, error) {
 			ch <- err
 			return
 		}
-		defer conn.Close()
+		defer func() {
+			_ = conn.Close()
+		}()
 		tlsconn := tls.Client(conn, tlsConfig)
 		err = tlsconn.Handshake()
 		if err != nil {
 			ch <- err
 			return
 		}
-		defer tlsconn.Close()
+		defer func() {
+			_ = tlsconn.Close()
+		}()
 
 		certs = tlsconn.ConnectionState().PeerCertificates
 		ch <- nil
@@ -97,7 +101,7 @@ func (opt *Opt) Verify() (string, error) {
 	displayServer := fmt.Sprintf(`%s port %d sni %s`, opt.Hostname, opt.Port, displaySNI)
 
 	if err != nil {
-		return "", fmt.Errorf("SSL CERTIFICATE CRITICAL: %v on %s", err, displayServer)
+		return "", fmt.Errorf("SSL CERTIFICATE CRITICAL: %w on %s", err, displayServer)
 	}
 
 	cert := certs[0]
@@ -110,9 +114,9 @@ func (opt *Opt) Verify() (string, error) {
 		for _, c := range certs[1:] {
 			verifyOpt.Intermediates.AddCert(c)
 		}
-		verifiedChains, err := certs[0].Verify(verifyOpt)
-		if err != nil {
-			return "", fmt.Errorf("SSL CERTIFICATE CRITICAL: failed verify chains [%v] on %s", err, displayServer)
+		verifiedChains, errVerify := certs[0].Verify(verifyOpt)
+		if errVerify != nil {
+			return "", fmt.Errorf("SSL CERTIFICATE CRITICAL: failed verify chains [%w] on %s", errVerify, displayServer)
 		}
 		if len(verifiedChains) == 0 {
 			return "", fmt.Errorf("SSL CERTIFICATE CRITICAL: failed verify chains [%v] on %s", "no verified chains", displayServer)
@@ -120,9 +124,8 @@ func (opt *Opt) Verify() (string, error) {
 	}
 
 	if opt.VerifySNI {
-		err := cert.VerifyHostname(opt.SNI)
-		if err != nil {
-			return "", fmt.Errorf("SSL CERTIFICATE CRITICAL: failed verify hostname [%v] on %s", err, displayServer)
+		if errVerifyHostname := cert.VerifyHostname(opt.SNI); errVerifyHostname != nil {
+			return "", fmt.Errorf("SSL CERTIFICATE CRITICAL: failed verify hostname [%w] on %s", errVerifyHostname, displayServer)
 		}
 	}
 

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -27,7 +27,7 @@ func newOpt(h string) Opt {
 func retryWithVerfy(opt Opt, retry int) (string, error) {
 	var err error
 	var msg string
-	for i := 0; i < retry; i++ {
+	for range retry {
 		msg, err = opt.Verify()
 		if err == nil {
 			return msg, nil

--- a/main.go
+++ b/main.go
@@ -3,40 +3,49 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/jessevdk/go-flags"
 )
 
 var version string
+var commit string
 
-const UNKNOWN = 3
-const CRITICAL = 2
-const WARNING = 1
-const OK = 0
-
-func printVersion() {
-	fmt.Printf(`%s Compiler: %s %s`,
-		version,
-		runtime.Compiler,
-		runtime.Version())
-}
+const (
+	OK = iota
+	WARNING
+	CRITICAL
+	UNKNOWN
+)
 
 func main() {
 	os.Exit(_main())
 }
 
 func _main() int {
-	opt := Opt{}
-	psr := flags.NewParser(&opt, flags.Default)
+	opt := &Opt{}
+	psr := flags.NewParser(opt, flags.HelpFlag|flags.PassDoubleDash)
 	_, err := psr.Parse()
-	if err != nil {
-		os.Exit(UNKNOWN)
-	}
-
 	if opt.Version {
-		printVersion()
+		if commit == "" {
+			commit = "dev"
+		}
+		fmt.Printf(
+			"%s-%s\n%s/%s, %s, %s\n",
+			filepath.Base(os.Args[0]),
+			version,
+			runtime.GOOS,
+			runtime.GOARCH,
+			runtime.Version(),
+			commit)
 		return OK
+	} else if flags.WroteHelp(err) {
+		fmt.Fprintf(os.Stdout, "%v\n", err)
+		return OK
+	} else if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		return UNKNOWN
 	}
 
 	if opt.TCP4 && opt.TCP6 {


### PR DESCRIPTION
### **User description**
- add make lint
- fix lint issues
- improve error handling and flags


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix lint warnings across certificate and CLI code

- Wrap errors with `%w` for chain inspection

- Improve flag parsing, help, and version output

- Add `make lint` target and git commit embedding


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Source code"] --> B["golangci-lint run"]
  B --> C["Fix lint issues"]
  C --> D["Wrap errors with %w"]
  C --> E["Clean up defer Close"]
  F["Makefile"] --> G["Add lint target"]
  F --> H["Embed git commit"]
  I["main.go"] --> J["Improve flag parsing & version"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>certificate.go</strong><dd><code>Fix lint issues and wrap certificate errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

certificate.go

<ul><li>Replace bare <code>defer conn.Close()</code> with anonymous func ignoring return <br>value<br> <li> Use <code>%w</code> verb to wrap errors in <code>fmt.Errorf</code><br> <li> Rename shadowed <code>err</code> variables in verification paths<br> <li> Improve error handling consistency in <code>Verify</code></ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/check_ssl_certificate2/pull/27/files#diff-acbfe7d6cdb1704e593e4d046b9889c0a25dafa6b3dfb168830bd4b5f5ae385b">+12/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>certificate_test.go</strong><dd><code>Modernize retry loop syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

certificate_test.go

- Replace C-style `for` loop with `for range retry`


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/check_ssl_certificate2/pull/27/files#diff-4185515bb45885cbb5721004137f7b070175b9c8944448863631fe04a4686d51">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Improve CLI flag handling and version output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.go

<ul><li>Switch exit constants to <code>iota</code> and reorder values<br> <li> Use <code>flags.HelpFlag|flags.PassDoubleDash</code> parser options<br> <li> Add commit to version output and handle help/errors<br> <li> Print usage/help to stdout and errors to stderr</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/check_ssl_certificate2/pull/27/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261">+27/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Add lint target and embed git commit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<ul><li>Add <code>GITCOMMIT</code> variable and pass to <code>main.commit</code><br> <li> Replace <code>fmt</code> target with <code>lint</code> using golangci-lint<br> <li> Use wildcard <code>*.go</code> as build prerequisites<br> <li> Add verbose flag to <code>go test</code></ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/check_ssl_certificate2/pull/27/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

